### PR TITLE
Use OSLog for component logs

### DIFF
--- a/HealthPal/Views/Components/MedicationCardView.swift
+++ b/HealthPal/Views/Components/MedicationCardView.swift
@@ -8,10 +8,16 @@
 
 import SwiftUI
 import SwiftData
+import OSLog
 
 struct MedicationCardView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var userPreferences: [UserPreferences]
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "HealthPal",
+        category: "MedicationCardView"
+    )
     
     let medication: Medication
     let reminderTime: ReminderTime
@@ -381,7 +387,7 @@ struct MedicationCardView: View {
     private func scheduleSnoozeNotification(duration: Int) {
         // This would integrate with UNUserNotificationCenter
         // For now, just a placeholder
-        print("Scheduling snooze notification for \(duration) minutes")
+        logger.debug("Scheduling snooze notification for \(duration) minutes")
     }
 }
 

--- a/HealthPal/Views/Components/QuickSymptomCheckView.swift
+++ b/HealthPal/Views/Components/QuickSymptomCheckView.swift
@@ -7,10 +7,16 @@
 
 import SwiftUI
 import SwiftData
+import OSLog
 
 struct QuickSymptomCheckView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
+
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "HealthPal",
+        category: "QuickSymptomCheckView"
+    )
     
     @State private var painLevel: Int = 3
     @State private var fatigueLevel: Int = 3
@@ -231,7 +237,7 @@ struct QuickSymptomCheckView: View {
             try modelContext.save()
             dismiss()
         } catch {
-            print("Error saving symptom entry: \(error)")
+            logger.error("Error saving symptom entry: \(error.localizedDescription)")
         }
     }
 }

--- a/HealthPal/Views/Components/SnoozeOptionsView.swift
+++ b/HealthPal/Views/Components/SnoozeOptionsView.swift
@@ -6,13 +6,18 @@
 //
 
 import SwiftUI
+import OSLog
 
 struct SnoozeOptionsView: View {
     let medication: Medication
     let reminderTime: ReminderTime
     let onSnooze: (Int, DelayReason?) -> Void
-    
+
     @Environment(\.dismiss) private var dismiss
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "HealthPal",
+        category: "SnoozeOptionsView"
+    )
     @State private var selectedDuration: Int = 15
     @State private var selectedReason: DelayReason?
     @State private var showingReasonPicker = false
@@ -227,7 +232,9 @@ struct DelayReasonPickerView: View {
         medication: medication,
         reminderTime: reminderTime,
         onSnooze: { duration, reason in
-            print("Snoozed for \(duration) minutes, reason: \(reason?.displayName ?? "none")")
+            logger.debug(
+                "Snoozed for \(duration) minutes, reason: \(reason?.displayName ?? \"none\")"
+            )
         }
     )
 }


### PR DESCRIPTION
## Summary
- replace `print` calls with Apple's unified logging
- log errors and debug messages with `Logger`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6883994f3e148323b823ef70b51fe195