### PR TITLE
Add model and navigation tests

### DIFF
--- a/HealthPalTests/AdherenceLogTests.swift
+++ b/HealthPalTests/AdherenceLogTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import HealthPal
+
+struct AdherenceLogTests {
+    @Test func testMarkAsTakenSetsValues() throws {
+        let medId = UUID()
+        let now = Date()
+        var log = AdherenceLog(medicationId: medId, scheduledDate: now, scheduledTime: now)
+        let taken = now.addingTimeInterval(5 * 60)
+        log.markAsTaken(at: taken, method: .quickTap, notes: "with food")
+        #expect(log.status == .taken)
+        #expect(log.actualTakenTime == taken)
+        #expect(log.entryMethod == .quickTap)
+        #expect(log.notes == "with food")
+        #expect(log.isOnTime)
+        #expect(log.totalDelayMinutes == 5)
+    }
+
+    @Test func testMarkAsTakenDelayed() throws {
+        let medId = UUID()
+        let now = Date()
+        var log = AdherenceLog(medicationId: medId, scheduledDate: now, scheduledTime: now)
+        let taken = now.addingTimeInterval(45 * 60)
+        log.markAsTaken(at: taken)
+        #expect(!log.isOnTime)
+        #expect(log.totalDelayMinutes == 45)
+    }
+}
+

--- a/HealthPalTests/SymptomEntryTests.swift
+++ b/HealthPalTests/SymptomEntryTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import HealthPal
+
+struct SymptomEntryTests {
+    @Test func testHasAnySymptoms() throws {
+        let entry = SymptomEntry(painLevel: 2)
+        #expect(entry.hasAnySymptoms)
+    }
+
+    @Test func testOverallWellnessCalculation() throws {
+        let entry = SymptomEntry(painLevel: 3, fatigueLevel: 2, moodLevel: 4)
+        if let wellness = entry.overallWellness {
+            #expect(abs(wellness - 11.0/3.0) < 0.0001)
+        } else {
+            #expect(false, "Wellness should not be nil")
+        }
+    }
+}
+

--- a/HealthPalUITests/HealthPalUITests.swift
+++ b/HealthPalUITests/HealthPalUITests.swift
@@ -24,11 +24,21 @@ final class HealthPalUITests: XCTestCase {
 
     @MainActor
     func testExample() throws {
-        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssertTrue(app.navigationBars["Today"].waitForExistence(timeout: 2))
+    }
+
+    @MainActor
+    func testTabNavigation() throws {
         let app = XCUIApplication()
         app.launch()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        XCTAssertTrue(app.navigationBars["Today"].waitForExistence(timeout: 2))
+        app.tabBars.buttons["Medications"].tap()
+        XCTAssertTrue(app.navigationBars["My Medications"].waitForExistence(timeout: 2))
+        app.tabBars.buttons["Settings"].tap()
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 2))
     }
 
     @MainActor
@@ -39,3 +49,4 @@ final class HealthPalUITests: XCTestCase {
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- add unit tests for `AdherenceLog` and `SymptomEntry`
- verify that Today tab appears on app launch and navigate across tabs in UI tests

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68839950a0e88323b3670d26023ce1a0