### PR TITLE
Fix symptom tracking query

### DIFF
--- a/HealthPal/Views/TodayView.swift
+++ b/HealthPal/Views/TodayView.swift
@@ -13,6 +13,7 @@ struct TodayView: View {
     @Environment(\.modelContext) private var modelContext
     @Query private var medications: [Medication]
     @Query private var adherenceLogs: [AdherenceLog]
+    @Query private var symptomEntries: [SymptomEntry]
     @Query private var userPreferences: [UserPreferences]
     
     @State private var showingSymptomCheck = false
@@ -208,8 +209,8 @@ struct TodayView: View {
     
     private var hasLoggedSymptomsToday: Bool {
         let today = Calendar.current.startOfDay(for: Date())
-        return adherenceLogs.contains { log in
-            Calendar.current.isDate(log.loggedTime, inSameDayAs: today)
+        return symptomEntries.contains { entry in
+            Calendar.current.isDate(entry.date, inSameDayAs: today)
         }
     }
     
@@ -295,5 +296,5 @@ struct TodayView: View {
 
 #Preview {
     TodayView()
-        .modelContainer(for: [Medication.self, AdherenceLog.self, UserPreferences.self], inMemory: true)
+        .modelContainer(for: [Medication.self, AdherenceLog.self, SymptomEntry.self, UserPreferences.self], inMemory: true)
 }


### PR DESCRIPTION
## Summary
- include `SymptomEntry` in TodayView queries
- check for symptom entries when deciding if symptoms were logged today
- update preview's model container

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6883be7fffc4832395db13f6c19fe483