### PR TITLE
Use OSLog for component view logs

### DIFF
--- a/HealthPal/Views/Components/MedicationCardView.swift
+++ b/HealthPal/Views/Components/MedicationCardView.swift
@@ -8,6 +8,12 @@
 
 import SwiftUI
 import SwiftData
+import OSLog
+
+private let medicationLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "HealthPal",
+    category: "MedicationCardView"
+)
 
 struct MedicationCardView: View {
     @Environment(\.modelContext) private var modelContext
@@ -381,7 +387,7 @@ struct MedicationCardView: View {
     private func scheduleSnoozeNotification(duration: Int) {
         // This would integrate with UNUserNotificationCenter
         // For now, just a placeholder
-        print("Scheduling snooze notification for \(duration) minutes")
+        medicationLogger.info("Scheduling snooze notification for \(duration) minutes")
     }
 }
 

--- a/HealthPal/Views/Components/QuickSymptomCheckView.swift
+++ b/HealthPal/Views/Components/QuickSymptomCheckView.swift
@@ -7,6 +7,12 @@
 
 import SwiftUI
 import SwiftData
+import OSLog
+
+private let symptomLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "HealthPal",
+    category: "QuickSymptomCheckView"
+)
 
 struct QuickSymptomCheckView: View {
     @Environment(\.modelContext) private var modelContext
@@ -231,7 +237,7 @@ struct QuickSymptomCheckView: View {
             try modelContext.save()
             dismiss()
         } catch {
-            print("Error saving symptom entry: \(error)")
+            symptomLogger.error("Error saving symptom entry: \(error.localizedDescription)")
         }
     }
 }

--- a/HealthPal/Views/Components/SnoozeOptionsView.swift
+++ b/HealthPal/Views/Components/SnoozeOptionsView.swift
@@ -6,6 +6,12 @@
 //
 
 import SwiftUI
+import OSLog
+
+private let snoozeLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "HealthPal",
+    category: "SnoozeOptionsView"
+)
 
 struct SnoozeOptionsView: View {
     let medication: Medication
@@ -227,7 +233,7 @@ struct DelayReasonPickerView: View {
         medication: medication,
         reminderTime: reminderTime,
         onSnooze: { duration, reason in
-            print("Snoozed for \(duration) minutes, reason: \(reason?.displayName ?? "none")")
+            snoozeLogger.info("Snoozed for \(duration) minutes, reason: \(reason?.displayName ?? "none")")
         }
     )
 }


### PR DESCRIPTION
## Summary
- replace `print` calls with unified logging in component views
- add OSLog imports and create loggers per view

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883be80ec5883238466822c68a2cbc6